### PR TITLE
🐛 Rollback `toBigInt` and `fromBigInt` from v3.3.12 method because of…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog
 =========
 =========
 
+#### Version 3.3.15
+* Rollback `toBigInt` and `fromBigInt` from v3.3.12 method because of float calculation error
+
 #### Version 3.3.14
 * Rollback "Add decimal property in `toBigInt` and `fromBigInt` method" because the Blockchain will manage directly decimals
 

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -39,28 +39,23 @@ Uint8List concatUint8List(Iterable<Uint8List> list) =>
 
 /// Convert any number into a big int for 10^8 decimals
 /// @param {num} Number to convert
-/// @param {num} Number to of decimals
 int toBigInt(num? number) {
-  const decimal = 8;
   if (number == null) {
     return 0;
   }
-  var nb = number;
-  for (var i = 0; i < decimal; i++) {
-    nb *= 10;
-  }
-  return nb.truncate();
+  return (Decimal.parse(number.toString()) * Decimal.parse('100000000'))
+      .toDouble()
+      .floor();
 }
 
 /// Convert big int of 10^8 decimals to any number
 /// @param {int} Number to convert
 num fromBigInt(int? number) {
-  const decimal = 8;
   if (number == null) {
     return 0;
   }
-  final divisor = Decimal.parse('10').pow(decimal).toDecimal();
-  return (Decimal.parse(number.toString()) / divisor).toDouble();
+  return (Decimal.parse(number.toString()) / Decimal.parse('100000000'))
+      .toDouble();
 }
 
 /// Convert any number into a byte array

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ name: archethic_lib_dart
 description: Archethic dart library for Flutter for Node and Browser. This library aims to provide a easy way to create Archethic transaction and to send them over the network
 homepage: https://github.com/archethic-foundation/libdart
 
-version: 3.3.14
+version: 3.3.15
 
 environment:
   sdk: ">=3.3.0 <4.0.0"

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -60,6 +60,10 @@ void main() {
     test('should return Big Int with 8 decimals by default', () {
       expect(toBigInt(12.5345), 1253450000);
     });
+
+    test('test precision', () {
+      expect(120139.69456927, fromBigInt(12013969456927));
+    });
   });
 
   group('fromBigInt', () {


### PR DESCRIPTION
… float calculation error